### PR TITLE
Fix V568, V579, V512 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/cgit.c
+++ b/cgit.c
@@ -159,7 +159,7 @@ static void querystring_cb(const char *name, const char *value)
 
 static void prepare_context(struct cgit_context *ctx)
 {
-	memset(ctx, 0, sizeof(ctx));
+        memset(ctx, 0, sizeof(*ctx));
 	ctx->cfg.agefile = "info/web/last-modified";
 	ctx->cfg.nocache = 0;
 	ctx->cfg.cache_size = 0;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warnings:
* It's odd that 'sizeof()' operator evaluates the size of a pointer to a class, but not the size of the 'ctx' class object.
* The memset function receives the pointer and its size as arguments. It is possibly a mistake.
* A call of the 'memset' function will lead to underflow of the buffer 'ctx'.